### PR TITLE
update to 3.0.1

### DIFF
--- a/com.blockstream.Green.metainfo.xml
+++ b/com.blockstream.Green.metainfo.xml
@@ -31,20 +31,24 @@
   <launchable type="desktop-id">com.blockstream.Green.desktop</launchable>
   <url type="homepage">https://blockstream.com/green</url>
   <releases>
-	  <release version="2.0.28" date="2025-08-06">
+	  <release version="3.0.1" date="2026-01-27">
 		  <description>
+        <p>Added</p>
+        <ul>
+          <li>Buy events</li>
+        </ul>
         <p>Changed</p>
-          <ul>
-            <li>Update GDK to 0.75.2</li>
-            <li>Update crashpad</li>
-          </ul>
+        <ul>
+          <li>Improved send flow when the wallet does not have liquid assets</li>
+          <li>Better look and feel consistency of some controls</li>
+        </ul>
         <p>Fixes</p>
-          <ul>
-            <li>Ensure that the legacy uninstalled on Windows works as expected</li>
-            <li>Fix the type label for not unblindable transaction</li>
-            <li>Prevent crash during transactions update</li>
-            <li>Prevent crash when changing a transaction note</li>
-          </ul>
+        <ul>
+          <li>Amounts when exporting transactions to CSV file</li>
+          <li>Load all transactions of a watchonly wallet</li>
+          <li>Exclude archived accounts to compute total wallet balance</li>
+          <li>Crash during application quit</li>
+        </ul>
 		  </description>
 	  </release>
   </releases>

--- a/com.blockstream.Green.metainfo.xml
+++ b/com.blockstream.Green.metainfo.xml
@@ -30,6 +30,7 @@
   
   <launchable type="desktop-id">com.blockstream.Green.desktop</launchable>
   <url type="homepage">https://blockstream.com/green</url>
+  <url type="vcs-browser">https://github.com/blockstream/green_qt</url>
   <releases>
 	  <release version="3.0.1" date="2026-01-27">
 		  <description>
@@ -55,7 +56,8 @@
 
   <screenshots>
     <screenshot type="default">
-      <image>https://blog.blockstream.com/content/images/size/w2000/2024/02/Green-2.0.png</image>
+      <image>https://blog.blockstream.com/content/images/size/w1000/2026/01/App_Desktop_3.0.0.jpg</image>
+      <caption>Main wallet overview</caption>
     </screenshot>
   </screenshots>
 </component>

--- a/com.blockstream.Green.yml
+++ b/com.blockstream.Green.yml
@@ -17,24 +17,21 @@ modules:
   - name: green
     buildsystem: simple
     build-commands:
-      - install -D blockstream ${FLATPAK_DEST}/bin/blockstream
-      - desktop-file-install --dir ${FLATPAK_DEST}/share/applications blockstream.desktop 
-      - install -Dm644 linux_production.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/linux_production.png
+      - chmod +x Blockstream-x86_64.AppImage
+      - ./Blockstream-x86_64.AppImage --appimage-extract
+      - cp -a squashfs-root/usr/* ${FLATPAK_DEST}/
       - install -Dm644 com.blockstream.Green.metainfo.xml ${FLATPAK_DEST}/share/metainfo/com.blockstream.Green.metainfo.xml
 
     sources:
-      - type: archive
-        url: https://github.com/Blockstream/green_qt/releases/download/release_2.0.28/Blockstream-linux-x86_64.tar.gz 
-        sha256: 29ec28d3ae308b2da3311aaba8ffbe6b2fb3ada1f59a368ae22f8cee3b9fa9b1
-        strip-components: 0
-
       - type: file
-        url: https://github.com/Blockstream/green_qt/raw/release_2.0.28/assets/icons/linux_production.png
-        sha256: 470ede780a248b38161ef0ffdb2a4a87efb6aedcdf8a1cfe17b3b2cf32275bce
-
-      - type: file
-        url: https://github.com/Blockstream/green_qt/raw/release_2.0.28/blockstream.desktop
-        sha256: c8180ffdedaea497fa3103f974c66dfbf60a471c3f1692f21b6a8c61f4807f72
+        url: https://github.com/Blockstream/green_qt/releases/download/release_3.0.1/Blockstream-x86_64.AppImage
+        sha256: fe1f1652d646caff7b8f4b4d6983aa5f8b919cd5998c2b4b6f3de38747b9c4f7
+        dest-filename: Blockstream-x86_64.AppImage
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/Blockstream/green_qt/releases/latest
+          url-query: .assets[] | select(.name=="Blockstream-x86_64.AppImage") | .browser_download_url
+          version-query: .tag_name | sub("^release_"; "")
 
       - type: file
         path: com.blockstream.Green.metainfo.xml


### PR DESCRIPTION
Update to latest Blockstream version.
Note: we switched the build process to use the production AppImage instead of a tarball.